### PR TITLE
fix rank_cut setting and minor problems

### DIFF
--- a/Unbiased_LTR/DLA/DLA_model.py
+++ b/Unbiased_LTR/DLA/DLA_model.py
@@ -86,7 +86,8 @@ class DLA(object):
 			#learning_rate_decay_factor=0.8, # Learning rate decays by this much.
 			max_gradient_norm=5.0,			# Clip gradients to this norm.
 			#reverse_input=True,				# Set to True for reverse input sequences.
-			hidden_layer_sizes=[512, 256, 128],		# Number of neurons in each layer of a RankNet. 
+			hidden_layer_sizes=[512, 256, 128],		# Number of neurons in each layer of a RankNet.
+			num_layers=4,
 			loss_func='click_weighted_softmax_cross_entropy',			# Select Loss function
 			logits_to_prob='softmax',		# the function used to convert logits to probability distributions
 			ranker_learning_rate=-1.0, 		# The learning rate for ranker (-1 means same with learning_rate).

--- a/Unbiased_LTR/DLA/main.py
+++ b/Unbiased_LTR/DLA/main.py
@@ -49,6 +49,8 @@ tf.app.flags.DEFINE_boolean("decode_train", False,
 # To be discarded.
 tf.app.flags.DEFINE_boolean("feed_previous", False,
                             "Set to True for feed previous internal output for training.")
+tf.app.flags.DEFINE_boolean("self_test", False,
+                            "Set to True for self-testing.")
 
 
 

--- a/Unbiased_LTR/click_models.py
+++ b/Unbiased_LTR/click_models.py
@@ -1,5 +1,6 @@
 import os,sys
 import random, json
+from six.moves import xrange
 
 
 def loadModelFromJson(model_desc):

--- a/Unbiased_LTR/data_utils.py
+++ b/Unbiased_LTR/data_utils.py
@@ -17,9 +17,11 @@ import numpy as np
 import json
 import random
 import os
+from six.moves import xrange
+
 
 class Raw_data:
-	def __init__(self, data_path = None, file_prefix = None, rank_cut=100000):
+	def __init__(self, data_path = None, file_prefix = None, rank_cut=500):
 		if data_path == None:
 			self.embed_size = -1
 			self.rank_list_size = -1
@@ -33,7 +35,7 @@ class Raw_data:
 
 		settings = json.load(open(data_path + 'settings.json'))
 		self.embed_size = settings['embed_size']
-		self.rank_list_size = rank_cut if rank_cut<settings['rank_cutoff'] else settings['rank_cutoff']
+		self.rank_list_size = rank_cut
 
 		self.features = []
 		self.dids = []
@@ -88,7 +90,7 @@ class Raw_data:
 				#self.initial_scores[i] += [0.0] * (self.rank_list_size - len(self.initial_scores[i]))
 
 
-def read_data(data_path, file_prefix, rank_cut = 100000):
+def read_data(data_path, file_prefix, rank_cut = 500):
 	data = Raw_data(data_path, file_prefix, rank_cut)
 	return data
 


### PR DESCRIPTION
Hi Qingyao,

I fixed some problems,  these are details:

1)  add missing num_layers setting for the bug appeared in DLA/main.py
print("Created %d layers of %d units." % (model.hparams.num_layers, model.embed_size))

2) add missing flag: self_test

3) import six for  the use of xrange in python3

4) the most important problem: 
I found the rank_cut setting does not work when evaluate, because the generated test.ranklist file does not cover all documents under the condition that the rank_cut is equal to 10 all the time.

I modified the code as I understand, I trained 2k epochs,  then eval in the original code, here is the result by trec_eval:
ndcg_cut_1            	all	0.6971
ndcg_cut_3            	all	0.6950
ndcg_cut_5            	all	0.7076
ndcg_cut_10           all	0.7373
map                   	all	0.5383
runid                 	all	RankLSTM
num_q                 	all	6983
num_ret               	all	**63481**
num_rel               	all	123035
num_rel_ret           	all	50891


Then I used the modified code to generate new test.ranklist with the same model, here is the updated result by trec_eval:
ndcg_cut_1            	all	0.7126
ndcg_cut_3            	all	0.7101
ndcg_cut_5            	all	0.7243
ndcg_cut_10           all	0.7639
map                   	all	0.8443
runid                 	all	RankLSTM
num_q                 	all	6983
num_ret               	all	**165660**
num_rel               	all	123035
num_rel_ret           	all	123035

You can clearly see the difference in the two test.ranklist files.(the doc numbers are different)
The performance might be higher than results in the paper due to the use of a different dataset.  But I am wondering is it the code version that your result reached in the original paper. If that, then it can be underestimated.
